### PR TITLE
Updates the link where students can find their OAuth token

### DIFF
--- a/lib/learn_config/cli.rb
+++ b/lib/learn_config/cli.rb
@@ -12,7 +12,7 @@ module LearnConfig
         puts <<-LONG
 To connect with the Learn web application, you will need to configure
 the Learn gem with an OAuth token. You can find yours at the bottom of your profile
-page at: https://learn.co/#{github_username ? github_username : 'your-github-username'}.
+page at: https://base.flatironschool.com/account/manage
 
         LONG
 

--- a/lib/learn_config/cli.rb
+++ b/lib/learn_config/cli.rb
@@ -10,9 +10,9 @@ module LearnConfig
     def ask_for_oauth_token(short_text: false, retries_remaining: 5)
       if !short_text
         puts <<-LONG
-To connect with the Learn web application, you will need to configure
-the Learn gem with an OAuth token. You can find yours on your Canvas account management
-page at: https://base.flatironschool.com/account/manage
+In order to receive credit for your work, you will need to configure
+the Learn gem with an OAuth token. You can find yours in Base at:
+  https://base.flatironschool.com/account/manage
 
         LONG
 

--- a/lib/learn_config/cli.rb
+++ b/lib/learn_config/cli.rb
@@ -11,7 +11,7 @@ module LearnConfig
       if !short_text
         puts <<-LONG
 To connect with the Learn web application, you will need to configure
-the Learn gem with an OAuth token. You can find yours at the bottom of your profile
+the Learn gem with an OAuth token. You can find yours here on your Canvas account management
 page at: https://base.flatironschool.com/account/manage
 
         LONG

--- a/lib/learn_config/cli.rb
+++ b/lib/learn_config/cli.rb
@@ -11,7 +11,7 @@ module LearnConfig
       if !short_text
         puts <<-LONG
 To connect with the Learn web application, you will need to configure
-the Learn gem with an OAuth token. You can find yours here on your Canvas account management
+the Learn gem with an OAuth token. You can find yours on your Canvas account management
 page at: https://base.flatironschool.com/account/manage
 
         LONG


### PR DESCRIPTION
The previous CLI file referred to the old learn.co location for students' OAuth token. This is just a minor change to direct students to their Canvas account to find the link instead.