### PR TITLE
Fixed location of OAuth link. Removed instance member github_username from CLI

### DIFF
--- a/lib/learn_config/cli.rb
+++ b/lib/learn_config/cli.rb
@@ -1,18 +1,13 @@
 module LearnConfig
   class CLI
-    attr_reader   :github_username
     attr_accessor :token
-
-    def initialize(github_username)
-      @github_username = github_username
-    end
 
     def ask_for_oauth_token(short_text: false, retries_remaining: 5)
       if !short_text
         puts <<-LONG
 To connect with the Learn web application, you will need to configure
 the Learn gem with an OAuth token. You can find yours at the bottom of your profile
-page at: https://learn.co/#{github_username ? github_username : 'your-github-username'}.
+page at: https://base.flatironschool.com/account/manage.
 
         LONG
 

--- a/lib/learn_config/setup.rb
+++ b/lib/learn_config/setup.rb
@@ -217,8 +217,7 @@ module LearnConfig
       login, password = netrc.read
 
       if (!login || !password) || !LearnWeb::Client.new(token: password, silent_output: true).valid_token?
-        github_username, _uid = netrc.read(machine: 'flatiron-push')
-        oauth_token = LearnConfig::CLI.new(github_username).ask_for_oauth_token
+        oauth_token = LearnConfig::CLI.new.ask_for_oauth_token
         netrc.write(new_login: 'learn', new_password: oauth_token)
       end
     end


### PR DESCRIPTION
Current OAuth link points to a depreciated site. It now points to the link https://base.flatironschool.com/account/manage which is where the key is now located. I removed the instance member github_username from the CLI class, as its only use was to interpolate their specific username into the CLI output. This is no longer needed, as the new link redirects the student to their specific page. Additionally, I removed the variable github_username from the Setup class, which was used as an argument to CLI's initialize method. Because CLI's github_username member has been removed, the init call no longer requires arguments.